### PR TITLE
Add backend entry point

### DIFF
--- a/beneva-sample/README.md
+++ b/beneva-sample/README.md
@@ -9,6 +9,19 @@ This sample project demonstrates a simplified version of the **Policy Builder** 
 * Dockerfile for containerization
 * Jenkinsfile for CI
 
+### Running the Backend
+Compile the project with Maven and use the `BackendApplication` entry point
+located under `com.beneva.sample.util`. Specify which module to run using one of
+the following options:
+
+```bash
+mvn package
+java -cp target/backend-0.0.1-SNAPSHOT.jar \
+    com.beneva.sample.util.BackendApplication claim
+```
+
+Valid arguments are `claim`, `policy` or `all` to start both modules.
+
 ## Frontend
 * React 17
 * Webpack configuration with Babel

--- a/beneva-sample/backend/src/main/java/com/beneva/sample/util/BackendApplication.java
+++ b/beneva-sample/backend/src/main/java/com/beneva/sample/util/BackendApplication.java
@@ -1,0 +1,31 @@
+package com.beneva.sample.util;
+
+import com.beneva.sample.claim.ClaimManagementApplication;
+import com.beneva.sample.policy.PolicyBuilderApplication;
+import org.springframework.boot.SpringApplication;
+
+/**
+ * Entry point to run backend modules from a single main class.
+ */
+public class BackendApplication {
+    public static void main(String[] args) {
+        if (args.length == 0) {
+            System.err.println("Specify 'claim', 'policy' or 'all'");
+            return;
+        }
+        switch (args[0]) {
+            case "claim":
+                SpringApplication.run(ClaimManagementApplication.class, args);
+                break;
+            case "policy":
+                SpringApplication.run(PolicyBuilderApplication.class, args);
+                break;
+            case "all":
+                SpringApplication.run(ClaimManagementApplication.class, args);
+                SpringApplication.run(PolicyBuilderApplication.class, args);
+                break;
+            default:
+                System.err.println("Unknown option: " + args[0]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add BackendApplication to run Policy Builder and Claim Management modules
- document how to use the new entry point in README

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686b1f10daa0832e996ed690d0a778a5